### PR TITLE
Add AdMob banner and interstitial ads

### DIFF
--- a/gallery-cleaner/Views/Ads/InterstitialAd.swift
+++ b/gallery-cleaner/Views/Ads/InterstitialAd.swift
@@ -1,0 +1,38 @@
+import GoogleMobileAds
+import SwiftUI
+
+final class InterstitialAd: NSObject, GADFullScreenContentDelegate, ObservableObject {
+    private var interstitial: GADInterstitialAd?
+    private let adUnitID: String
+
+    init(adUnitID: String) {
+        self.adUnitID = adUnitID
+        super.init()
+        loadAd()
+    }
+
+    private func loadAd() {
+        let request = GADRequest()
+        GADInterstitialAd.load(withAdUnitID: adUnitID, request: request) { [weak self] ad, error in
+            if let error = error {
+                print("Failed to load interstitial ad: \(error.localizedDescription)")
+                return
+            }
+            self?.interstitial = ad
+            self?.interstitial?.fullScreenContentDelegate = self
+        }
+    }
+
+    func showAd(from root: UIViewController) {
+        guard let ad = interstitial else {
+            print("Interstitial ad is not ready")
+            loadAd()
+            return
+        }
+        ad.present(fromRootViewController: root)
+    }
+
+    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+        loadAd()
+    }
+}

--- a/gallery-cleaner/Views/GalleryView.swift
+++ b/gallery-cleaner/Views/GalleryView.swift
@@ -36,6 +36,8 @@ struct GalleryView: View {
                     }
                 }
                 trashButton
+                BannerAdView(adUnitID: "ca-app-pub-3940256099942544/2934735716")
+                    .frame(height: 50)
             }
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/gallery-cleaner/Views/HomeView.swift
+++ b/gallery-cleaner/Views/HomeView.swift
@@ -126,6 +126,8 @@ struct HomeView: View {
                     )
                 }
             }
+            BannerAdView(adUnitID: "ca-app-pub-3940256099942544/2934735716")
+                .frame(height: 50)
         }
         .background(theme.background)
         .onAppear {

--- a/gallery-cleaner/Views/MonthGalleryView.swift
+++ b/gallery-cleaner/Views/MonthGalleryView.swift
@@ -12,6 +12,7 @@ struct MonthGalleryView: View {
     @EnvironmentObject var trashManager: TrashManager
     @EnvironmentObject var viewModel: PhotoLibraryViewModel
     @State private var showTrash = false
+    @StateObject private var interstitialAd = InterstitialAd(adUnitID: "ca-app-pub-3940256099942544/4411468910")
     @Environment(\.theme) private var theme
     @ObservedObject var localization = LocalizationManager.shared
 
@@ -126,7 +127,14 @@ struct MonthGalleryView: View {
         .sheet(isPresented: $showTrash) {
             TrashView()
                 .environmentObject(trashManager)
-                .environmentObject(viewModel) 
+                .environmentObject(viewModel)
+        }
+        .onAppear {
+            if let root = UIApplication.shared.connectedScenes
+                .compactMap({ ($0 as? UIWindowScene)?.windows.first?.rootViewController })
+                .first {
+                interstitialAd.showAd(from: root)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- integrate BannerAdView on Home and Gallery screens
- show Interstitial ads when opening a month
- add InterstitialAd helper

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686410f5ee6883309410902e3b3d7b46