### PR TITLE
Implement StoreKit subscription and ad suppression

### DIFF
--- a/gallery-cleaner/Resources/StoreKit.storekit
+++ b/gallery-cleaner/Resources/StoreKit.storekit
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "products": [
+      {
+        "id": "com.example.subscription",
+        "type": "auto-renewable subscription",
+        "subscription": {
+          "groupID": "com.example.subscription.group",
+          "duration": "P1M"
+        },
+        "displayName": "Premium Access",
+        "displayPrice": "$1.99"
+      }
+    ]
+  },
+  "schema": "https://appstoreconnect.apple.com/schema/fastlane/latest/storekit.json"
+}

--- a/gallery-cleaner/Views/Ads/InterstitialAdManager.swift
+++ b/gallery-cleaner/Views/Ads/InterstitialAdManager.swift
@@ -10,7 +10,6 @@ final class InterstitialAdManager: NSObject, FullScreenContentDelegate, Observab
     init(adUnitID: String) {
         self.adUnitID = adUnitID
         super.init()
-        loadAd()
     }
 
     func loadAd() {
@@ -28,7 +27,6 @@ final class InterstitialAdManager: NSObject, FullScreenContentDelegate, Observab
     func showAd(from rootViewController: UIViewController) {
         guard let ad = interstitial else {
             print("⚠️ Interstitial ad is not ready yet.")
-            loadAd()
             return
         }
         ad.present(from: rootViewController)
@@ -43,6 +41,6 @@ final class InterstitialAdManager: NSObject, FullScreenContentDelegate, Observab
     func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
         print("✅ Interstitial ad was dismissed.")
         didDismissAd = true
-        loadAd()
+        interstitial = nil
     }
 }

--- a/gallery-cleaner/Views/Ads/RewardedAdManager.swift
+++ b/gallery-cleaner/Views/Ads/RewardedAdManager.swift
@@ -9,7 +9,6 @@ final class RewardedAdManager: NSObject, FullScreenContentDelegate, ObservableOb
     init(adUnitID: String) {
         self.adUnitID = adUnitID
         super.init()
-        loadAd()
     }
 
     // Завантаження реклами
@@ -29,7 +28,6 @@ final class RewardedAdManager: NSObject, FullScreenContentDelegate, ObservableOb
     func showAd(from rootViewController: UIViewController, rewardHandler: @escaping () -> Void) {
         guard let ad = rewardedAd else {
             print("⚠️ Rewarded ad is not ready yet.")
-            loadAd()
             return
         }
 
@@ -44,7 +42,7 @@ final class RewardedAdManager: NSObject, FullScreenContentDelegate, ObservableOb
 
     func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
         print("✅ Rewarded ad dismissed.")
-        loadAd()
+        rewardedAd = nil
     }
 
     func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {

--- a/gallery-cleaner/Views/Settings/SubscriptionSectionView.swift
+++ b/gallery-cleaner/Views/Settings/SubscriptionSectionView.swift
@@ -1,42 +1,47 @@
 import SwiftUI
 
-enum SubscriptionStatus: String {
-    case free, pro
-}
-
 struct SubscriptionSectionView: View {
-    @AppStorage("subscriptionStatus") private var subscriptionStatusRaw: String = "free"
+    @EnvironmentObject var storeKit: StoreKitManager
     @Environment(\.theme) private var theme
-
-    private var subscriptionStatus: SubscriptionStatus {
-        SubscriptionStatus(rawValue: subscriptionStatusRaw) ?? .free
-    }
 
     var body: some View {
         Section(header: Text("settings_subscription_header".localized)) {
             HStack {
                 Label("settings_current_plan".localized, systemImage: "person.crop.circle")
                 Spacer()
-                Text(subscriptionStatus == .pro ? "Pro" : "Free")
-                    .foregroundColor(subscriptionStatus == .pro ? .green : .gray)
+                Text(storeKit.isPremiumUser ? "Pro" : "Free")
+                    .foregroundColor(storeKit.isPremiumUser ? .green : .gray)
                     .fontWeight(.semibold)
             }
 
-            if subscriptionStatus == .free {
-                Button(action: {
-                    // Запуск покупки Pro
-                }) {
-                    Label("settings_upgrade_pro".localized, systemImage: "star.fill")
-                        .foregroundColor(theme.accent)
+            if storeKit.isPremiumUser {
+                Text("settings_subscription_active".localized)
+                    .foregroundColor(.green)
+            } else {
+                if let product = storeKit.products.first {
+                    Button(action: {
+                        Task { await storeKit.purchaseSubscription() }
+                    }) {
+                        Label("\("settings_upgrade_pro".localized) \(product.displayPrice)", systemImage: "star.fill")
+                            .foregroundColor(theme.accent)
+                    }
+                } else {
+                    ProgressView()
                 }
             }
 
             Button(action: {
-                // Відновлення покупок (Restore Purchases)
+                Task { await storeKit.restore() }
             }) {
                 Label("settings_restore_purchases".localized, systemImage: "arrow.clockwise")
                     .foregroundColor(theme.textPrimary)
             }
         }
     }
+}
+
+#Preview {
+    SubscriptionSectionView()
+        .environmentObject(StoreKitManager())
+        .environment(\.theme, Theme.default)
 }

--- a/gallery-cleaner/Views/TrashView.swift
+++ b/gallery-cleaner/Views/TrashView.swift
@@ -39,7 +39,9 @@ struct TrashView: View {
                     }
 
                     Button(role: .destructive) {
-                        if let rootVC = UIApplication.shared.connectedScenes
+                        if storeKit.isPremiumUser {
+                            trashManager.deleteAllFromLibrary(viewModel: viewModel)
+                        } else if let rootVC = UIApplication.shared.connectedScenes
                             .compactMap({ ($0 as? UIWindowScene)?.windows.first?.rootViewController })
                             .first {
                             adManager.showAd(from: rootVC)
@@ -59,10 +61,18 @@ struct TrashView: View {
                 }
             }
             .navigationTitle("trash_title".localized)
+            .onAppear {
+                if !storeKit.isPremiumUser {
+                    adManager.loadAd()
+                }
+            }
             .onReceive(adManager.$didDismissAd) { dismissed in
                 if dismissed && shouldDelete {
                     trashManager.deleteAllFromLibrary(viewModel: viewModel)
                     shouldDelete = false
+                }
+                if !storeKit.isPremiumUser {
+                    adManager.loadAd()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- implement `StoreKitManager` to manage subscription purchase and status
- create `SubscriptionSectionView` UI to purchase/restore subscription
- disable ads for premium users in TrashView
- update interstitial and rewarded ad managers to not auto-load
- add StoreKit configuration for local testing

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6867e6a0cc1c8330bc4a4046fd2ce7c9