### PR TITLE
Implement premium unlock with StoreKit

### DIFF
--- a/gallery-cleaner/Views/Ads/BannerAdView.swift
+++ b/gallery-cleaner/Views/Ads/BannerAdView.swift
@@ -14,7 +14,7 @@ struct BannerAdView: View {
 
     var body: some View {
         Group {
-            if !storeKit.isPremiumUser {
+            if !storeKit.isProUser {
                 BannerAdViewRepresentable(adUnitID: adUnitID)
                     .frame(height: 50)
             }

--- a/gallery-cleaner/Views/Ads/InterstitialAdManager.swift
+++ b/gallery-cleaner/Views/Ads/InterstitialAdManager.swift
@@ -14,6 +14,7 @@ final class InterstitialAdManager: NSObject, FullScreenContentDelegate, Observab
     }
 
     func loadAd() {
+        guard !UserDefaults.standard.bool(forKey: "isProUser") else { return }
         let request = Request()
         InterstitialAd.load(with: adUnitID, request: request, completionHandler: { [weak self] ad, error in
             if let error = error {
@@ -26,6 +27,7 @@ final class InterstitialAdManager: NSObject, FullScreenContentDelegate, Observab
     }
 
     func showAd(from rootViewController: UIViewController) {
+        guard !UserDefaults.standard.bool(forKey: "isProUser") else { return }
         guard let ad = interstitial else {
             print("⚠️ Interstitial ad is not ready yet.")
             loadAd()

--- a/gallery-cleaner/Views/Ads/RewardedAdManager.swift
+++ b/gallery-cleaner/Views/Ads/RewardedAdManager.swift
@@ -14,6 +14,7 @@ final class RewardedAdManager: NSObject, FullScreenContentDelegate, ObservableOb
 
     // Завантаження реклами
     func loadAd() {
+        guard !UserDefaults.standard.bool(forKey: "isProUser") else { return }
         let request = Request()
         RewardedAd.load(with: adUnitID, request: request) { [weak self] ad, error in
             if let error = error {
@@ -27,6 +28,7 @@ final class RewardedAdManager: NSObject, FullScreenContentDelegate, ObservableOb
 
     // Показ винагороджувальної реклами
     func showAd(from rootViewController: UIViewController, rewardHandler: @escaping () -> Void) {
+        guard !UserDefaults.standard.bool(forKey: "isProUser") else { return }
         guard let ad = rewardedAd else {
             print("⚠️ Rewarded ad is not ready yet.")
             loadAd()

--- a/gallery-cleaner/Views/TrashView.swift
+++ b/gallery-cleaner/Views/TrashView.swift
@@ -7,7 +7,6 @@ struct TrashView: View {
     @EnvironmentObject var storeKit: StoreKitManager
 
     @StateObject private var adManager = InterstitialAdManager(adUnitID: "ca-app-pub-3940256099942544/4411468910")
-    @State private var showAd = false
     @State private var shouldDelete = false
 
     let columns = [
@@ -42,8 +41,12 @@ struct TrashView: View {
                         if let rootVC = UIApplication.shared.connectedScenes
                             .compactMap({ ($0 as? UIWindowScene)?.windows.first?.rootViewController })
                             .first {
-                            adManager.showAd(from: rootVC)
-                            shouldDelete = true
+                            if storeKit.isProUser {
+                                trashManager.deleteAllFromLibrary(viewModel: viewModel)
+                            } else {
+                                adManager.showAd(from: rootVC)
+                                shouldDelete = true
+                            }
                         }
                     } label: {
                         Text("trash_delete_all".localized)


### PR DESCRIPTION
## Summary
- update StoreKitManager for non‑consumable purchase
- hide ads when premium is owned
- allow purchasing/restoring from Settings
- skip ads on delete when premium is active

## Testing
- `xcodebuild -list -project gallery-cleaner.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e061255c8833092ddf2f1dbfcbded